### PR TITLE
Replace Commons HttpClient with HttpComponents, misc. cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
     </parent>
 
     <scm>
@@ -19,129 +19,140 @@
         <url>git@github.com:mdiggory/SWORDv1.1</url>
     </scm>
 
-	<build>
-		<plugins>
+    <build>
+        <plugins>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <goals>deploy</goals>
                 </configuration>
             </plugin>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>org/purl/sword/SwordTest.java</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-			<!--  Invoke with mvn assembly:assembly -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<descriptors>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <excludes>
+                        <exclude>org/purl/sword/SwordTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <!--  Invoke with mvn assembly:assembly -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
                         <descriptor>src/main/assembly/distribution.xml</descriptor>
                     </descriptors>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-	<dependencies>
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.2</version>
+    <dependencies>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.6</version>
         </dependency>
-		<dependency>
-			<groupId>commons-httpclient</groupId>
-			<artifactId>commons-httpclient</artifactId>
-			<version>3.1</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.4</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.15</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>jmxtools</artifactId>
-					<groupId>com.sun.jdmk</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>jms</artifactId>
-					<groupId>javax.jms</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>jmxri</artifactId>
-					<groupId>com.sun.jmx</groupId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.jdesktop</groupId>
-			<artifactId>swing-worker</artifactId>
-			<version>1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>xom</groupId>
-			<artifactId>xom</artifactId>
-			<version>1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>1.3.1</version>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.15</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jmxtools</artifactId>
+                    <groupId>com.sun.jdmk</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jms</artifactId>
+                    <groupId>javax.jms</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jmxri</artifactId>
+                    <groupId>com.sun.jmx</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jdesktop</groupId>
+            <artifactId>swing-worker</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>xom</groupId>
+            <artifactId>xom</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+    </dependencies>
 
     <profiles>
         <profile>
             <id>distribution</id>
             <build>
                 <plugins>
-                   <plugin>
-                       <groupId>org.apache.maven.plugins</groupId>
-                       <artifactId>maven-jar-plugin</artifactId>
-                       <configuration>
-                           <archive>
-                               <manifestEntries>
-                                 <Class-Path>. </Class-Path>
-                              </manifestEntries>
-                              <manifest>
-                                  <addClasspath>true</addClasspath>
-                                  <mainClass>org.purl.sword.client.ClientFactory</mainClass>
-                                  <classpathPrefix>libs/</classpathPrefix>
-                              </manifest>
-                           </archive>
-                           <excludes>
-                               <exclude>Licenses/**</exclude>
-                               <exclude>help/**</exclude>
-                               <exclude>*.properties</exclude>
-                           </excludes>
-                       </configuration>
-                   </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Class-Path>. </Class-Path>
+                                </manifestEntries>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <mainClass>org.purl.sword.client.ClientFactory</mainClass>
+                                    <classpathPrefix>libs/</classpathPrefix>
+                                </manifest>
+                            </archive>
+                            <excludes>
+                                <exclude>Licenses/**</exclude>
+                                <exclude>help/**</exclude>
+                                <exclude>*.properties</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
 </project>
-

--- a/src/main/java/org/purl/sword/client/Client.java
+++ b/src/main/java/org/purl/sword/client/Client.java
@@ -2,36 +2,36 @@
  * Copyright (c) 2008, Aberystwyth University
  *
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
  * are met:
- * 
- *  - Redistributions of source code must retain the above 
- *    copyright notice, this list of conditions and the 
+ *
+ *  - Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
  *    following disclaimer.
- *  
- *  - Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in 
- *    the documentation and/or other materials provided with the 
+ *
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
  *    distribution.
- *    
- *  - Neither the name of the Centre for Advanced Software and 
- *    Intelligent Systems (CASIS) nor the names of its 
- *    contributors may be used to endorse or promote products derived 
+ *
+ *  - Neither the name of the Centre for Advanced Software and
+ *    Intelligent Systems (CASIS) nor the names of its
+ *    contributors may be used to endorse or promote products derived
  *    from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR 
- * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF 
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
 package org.purl.sword.client;
@@ -40,23 +40,35 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.NoSuchAlgorithmException;
-
 import java.util.Properties;
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.commons.httpclient.auth.AuthScope;
-import org.apache.commons.httpclient.methods.FileRequestEntity;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
-import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.impl.auth.BasicSchemeFactory;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.log4j.Logger;
 import org.purl.sword.base.ChecksumUtils;
 import org.purl.sword.base.DepositResponse;
 import org.purl.sword.base.HttpHeaders;
-import org.purl.sword.base.SWORDErrorDocument;
 import org.purl.sword.base.ServiceDocument;
 import org.purl.sword.base.SwordValidationInfo;
 import org.purl.sword.base.UnmarshallException;
@@ -65,7 +77,7 @@ import org.purl.sword.base.UnmarshallException;
  * This is an example Client implementation to demonstrate how to connect to a
  * SWORD server. The client supports BASIC HTTP Authentication. This can be
  * initialised by setting a username and password.
- * 
+ *
  * @author Neil Taylor
  */
 public class Client implements SWORDClient {
@@ -107,7 +119,17 @@ public class Client implements SWORDClient {
 	/**
 	 * The client that is used to send data to the specified server.
 	 */
-	private HttpClient client;
+	private final HttpClientBuilder clientBuilder;
+
+        /**
+         * The client's connection manager.
+         */
+        private final BasicHttpClientConnectionManager connectionManager;
+
+        /**
+         * The client's execution context.
+         */
+        private final HttpClientContext context;
 
 	/**
 	 * The default connection timeout. This can be modified by using the
@@ -118,26 +140,38 @@ public class Client implements SWORDClient {
 	/**
 	 * Logger.
 	 */
-	private static Logger log = Logger.getLogger(Client.class);
+	private static final Logger log = Logger.getLogger(Client.class);
 
 	/**
 	 * Create a new Client. The client will not use authentication by default.
 	 */
 	public Client() {
-		client = new HttpClient();
-		client.getParams().setParameter("http.socket.timeout",
-				new Integer(DEFAULT_TIMEOUT));
-		log.debug("proxy host: " + client.getHostConfiguration().getProxyHost());
-		log.debug("proxy port: " + client.getHostConfiguration().getProxyPort());
-        doAuthentication = false;
+            SocketConfig.Builder soConfig = SocketConfig.custom();
+            soConfig.setSoTimeout(DEFAULT_TIMEOUT);
+            connectionManager = new BasicHttpClientConnectionManager();
+            connectionManager.setSocketConfig(soConfig.build());
+
+            clientBuilder = HttpClientBuilder.create()
+                    .setConnectionManager(connectionManager);
+
+            context = HttpClientContext.create();
+            Registry<AuthSchemeProvider> authRegistry = RegistryBuilder
+                    .<AuthSchemeProvider>create()
+                    .register(AuthSchemes.BASIC, new BasicSchemeFactory())
+                    .build();
+            context.setAuthSchemeRegistry(authRegistry);
+            context.setAuthCache(new BasicAuthCache());
+
+            doAuthentication = false;
 	}
 
 	/**
 	 * Initialise the server that will be used to send the network access.
-	 * 
+	 *
 	 * @param server
 	 * @param port
 	 */
+        @Override
 	public void setServer(String server, int port) {
 		this.server = server;
 		this.port = port;
@@ -146,12 +180,13 @@ public class Client implements SWORDClient {
 	/**
 	 * Set the user credentials that will be used when making the access to the
 	 * server.
-	 * 
+	 *
 	 * @param username
 	 *            The username.
 	 * @param password
 	 *            The password.
 	 */
+        @Override
 	public void setCredentials(String username, String password) {
 		this.username = username;
 		this.password = password;
@@ -161,22 +196,25 @@ public class Client implements SWORDClient {
 	/**
 	 * Set the basic credentials. You must have previously set the server and
 	 * port using setServer.
-	 * 
+	 *
 	 * @param username
 	 * @param password
 	 */
 	private void setBasicCredentials(String username, String password) {
-		log.debug("server: " + server + " port: " + port + " u: '" + username
-				+ "' p '" + password + "'");
-		client.getState().setCredentials(new AuthScope(server, port),
-				new UsernamePasswordCredentials(username, password));
+            log.debug("server: " + server + " port: " + port + " u: '" + username
+                    + "' p '" + password + "'");
+
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(new AuthScope(server, port),
+                    new UsernamePasswordCredentials(username, password));
+            context.setCredentialsProvider(credsProvider);
 	}
 
 	/**
 	 * Set a proxy that should be used by the client when trying to access the
 	 * server. If this is not set, the client will attempt to make a direct
 	 * direct connection to the server. The port is set to 80.
-	 * 
+	 *
 	 * @param host
 	 *            The hostname.
 	 */
@@ -188,57 +226,63 @@ public class Client implements SWORDClient {
 	 * Set a proxy that should be used by the client when trying to access the
 	 * server. If this is not set, the client will attempt to make a direct
 	 * direct connection to the server.
-	 * 
+	 *
 	 * @param host
 	 *            The name of the host.
 	 * @param port
 	 *            The port.
 	 */
+        @Override
 	public void setProxy(String host, int port) {
-		client.getHostConfiguration().setProxy(host, port);
+            clientBuilder.setProxy(new HttpHost(host, port));
 	}
 
 	/**
 	 * Clear the proxy setting.
 	 */
 	public void clearProxy() {
-		client.getHostConfiguration().setProxyHost(null);
+            clientBuilder.setProxy(null);
 	}
 
-	/**
-	 * Clear any user credentials that have been set for this client.
-	 */
-	public void clearCredentials() {
-		client.getState().clearProxyCredentials();
-		doAuthentication = false;
-	}
+    /**
+     * Clear any user credentials that have been set for this client.
+     */
+    @Override
+    public void clearCredentials() {
+        context.getCredentialsProvider().clear();
+        doAuthentication = false;
+    }
 
     public void setUserAgent(String userAgent){
         this.userAgent = userAgent;
     }
-	/**
-	 * Set the connection timeout for the socket.
-	 * 
-	 * @param milliseconds
-	 *            The time, expressed as a number of milliseconds.
-	 */
-	public void setSocketTimeout(int milliseconds) {
-		client.getParams().setParameter("http.socket.timeout",
-				new Integer(milliseconds));
-	}
+
+    /**
+     * Set the connection timeout for the socket.
+     *
+     * @param milliseconds
+     *            The time, expressed as a number of milliseconds.
+     */
+    public void setSocketTimeout(int milliseconds) {
+        SocketConfig socketConfig = SocketConfig.custom()
+                .setSoTimeout(milliseconds)
+                .build();
+        clientBuilder.setDefaultSocketConfig(socketConfig);
+    }
 
 	/**
 	 * Retrieve the service document. The service document is located at the
 	 * specified URL. This calls getServiceDocument(url,onBehalfOf).
-	 * 
+	 *
 	 * @param url
 	 *            The location of the service document.
 	 * @return The ServiceDocument, or <code>null</code> if there was a
 	 *         problem accessing the document. e.g. invalid access.
-	 * 
+	 *
 	 * @throws SWORDClientException
 	 *             If there is an error accessing the resource.
 	 */
+        @Override
 	public ServiceDocument getServiceDocument(String url)
 			throws SWORDClientException {
 		return getServiceDocument(url, null);
@@ -247,15 +291,16 @@ public class Client implements SWORDClient {
 	/**
 	 * Retrieve the service document. The service document is located at the
 	 * specified URL. This calls getServiceDocument(url,onBehalfOf).
-	 * 
+	 *
 	 * @param url
 	 *            The location of the service document.
 	 * @return The ServiceDocument, or <code>null</code> if there was a
 	 *         problem accessing the document. e.g. invalid access.
-	 * 
+	 *
 	 * @throws SWORDClientException
 	 *             If there is an error accessing the resource.
 	 */
+        @Override
 	public ServiceDocument getServiceDocument(String url, String onBehalfOf)
 			throws SWORDClientException {
 		URL serviceDocURL = null;
@@ -265,7 +310,7 @@ public class Client implements SWORDClient {
 			// Try relative URL
 			URL baseURL = null;
 			try {
-				baseURL = new URL("http", server, Integer.valueOf(port), "/");
+				baseURL = new URL("http", server, port, "/");
 				serviceDocURL = new URL(baseURL, (url == null) ? "" : url);
 			} catch (MalformedURLException e1) {
 				// No dice, can't even form base URL...
@@ -275,57 +320,59 @@ public class Client implements SWORDClient {
 						+ baseURL + " / " + url, e1);
 			}
 		}
-		
-		GetMethod httpget = new GetMethod(serviceDocURL.toExternalForm());
+
+		HttpGet httpget = new HttpGet(serviceDocURL.toExternalForm());
 		if (doAuthentication) {
 			// this does not perform any check on the username password. It
 			// relies on the server to determine if the values are correct.
 			setBasicCredentials(username, password);
-			httpget.setDoAuthentication(true);
 		}
 
         Properties properties = new Properties();
 
 		if (containsValue(onBehalfOf)) {
 			log.debug("Setting on-behalf-of: " + onBehalfOf);
-			httpget.addRequestHeader(new Header(HttpHeaders.X_ON_BEHALF_OF,
-					onBehalfOf));
+			httpget.addHeader(HttpHeaders.X_ON_BEHALF_OF,
+					onBehalfOf);
             properties.put(HttpHeaders.X_ON_BEHALF_OF, onBehalfOf);
 		}
 
 		if (containsValue(userAgent)) {
 			log.debug("Setting userAgent: " + userAgent);
-			httpget.addRequestHeader(new Header(HttpHeaders.USER_AGENT,
-					userAgent));
+			httpget.addHeader(HttpHeaders.USER_AGENT,
+					userAgent);
             properties.put(HttpHeaders.USER_AGENT, userAgent);
 		}
 
 		ServiceDocument doc = null;
 
 		try {
-			client.executeMethod(httpget);
-			// store the status code
-			status = new Status(httpget.getStatusCode(), httpget
-					.getStatusText());
+                    HttpClient client = clientBuilder.build();
+                    HttpResponse httpResponse = client.execute(httpget, context);
+                    StatusLine statusLine = httpResponse.getStatusLine();
+                    // store the status code
+                    status = new Status(statusLine.getStatusCode(),
+                            statusLine.getReasonPhrase());
 
-			if (status.getCode() == HttpStatus.SC_OK) {
-				String message = readResponse(httpget.getResponseBodyAsStream());
-				log.debug("returned message is: " + message);
-				doc = new ServiceDocument();
-				lastUnmarshallInfo = doc.unmarshall(message, properties);
-			} else {
-				throw new SWORDClientException(
-						"Received error from service document request: "
-								+ status);
-			}
-		} catch (HttpException ex) {
-			throw new SWORDClientException(ex.getMessage(), ex);
+                    if (status.getCode() == HttpStatus.SC_OK) {
+                            String message = readResponse(httpResponse
+                                    .getEntity().getContent());
+                            log.debug("returned message is: " + message);
+                            doc = new ServiceDocument();
+                            lastUnmarshallInfo = doc.unmarshall(message, properties);
+                    } else {
+                        throw new SWORDClientException(
+                                "Received error from service document request: "
+                                + status);
+                    }
+		} catch (ClientProtocolException ex) {
+                    throw new SWORDClientException(ex.getMessage(), ex);
 		} catch (IOException ioex) {
-			throw new SWORDClientException(ioex.getMessage(), ioex);
+                    throw new SWORDClientException(ioex.getMessage(), ioex);
 		} catch (UnmarshallException uex) {
-			throw new SWORDClientException(uex.getMessage(), uex);
+                    throw new SWORDClientException(uex.getMessage(), uex);
 		} finally {
-			httpget.releaseConnection();
+                    httpget.releaseConnection();
 		}
 
 		return doc;
@@ -334,7 +381,7 @@ public class Client implements SWORDClient {
     private SwordValidationInfo lastUnmarshallInfo;
 
     /**
-     * 
+     *
      * @return
      */
     public SwordValidationInfo getLastUnmarshallInfo()
@@ -345,30 +392,30 @@ public class Client implements SWORDClient {
 	/**
 	 * Post a file to the server. The different elements of the post are encoded
 	 * in the specified message.
-	 * 
+	 *
 	 * @param message
 	 *            The message that contains the post information.
-	 * 
+	 *
 	 * @throws SWORDClientException
 	 *             if there is an error during the post operation.
 	 */
+        @Override
 	public DepositResponse postFile(PostMessage message)
 			throws SWORDClientException {
 		if (message == null) {
 			throw new SWORDClientException("Message cannot be null.");
 		}
 
-		PostMethod httppost = new PostMethod(message.getDestination());
+		HttpPost httppost = new HttpPost(message.getDestination());
 
 		if (doAuthentication) {
 			setBasicCredentials(username, password);
-			httppost.setDoAuthentication(true);
 		}
 
 		DepositResponse response = null;
 
 		String messageBody = "";
-		
+
 		try {
 			if (message.isUseMD5()) {
 				String md5 = ChecksumUtils.generateMD5(message.getFilepath());
@@ -377,101 +424,101 @@ public class Client implements SWORDClient {
 				}
 				log.debug("checksum error is: " + md5);
 				if (md5 != null) {
-					httppost.addRequestHeader(new Header(
-							HttpHeaders.CONTENT_MD5, md5));
+                                    httppost.addHeader(
+                                            HttpHeaders.CONTENT_MD5, md5);
 				}
 			}
 
 			String filename = message.getFilename();
 			if (! "".equals(filename)) {
-				httppost.addRequestHeader(new Header(
-						HttpHeaders.CONTENT_DISPOSITION, " filename="
-								+ filename));
+				httppost.addHeader(
+                                        HttpHeaders.CONTENT_DISPOSITION,
+                                        " filename=" + filename);
 			}
 
 			if (containsValue(message.getSlug())) {
-				httppost.addRequestHeader(new Header(HttpHeaders.SLUG, message
-						.getSlug()));
+				httppost.addHeader(HttpHeaders.SLUG, message
+						.getSlug());
 			}
 
             if(message.getCorruptRequest())
             {
                 // insert a header with an invalid boolean value
-                httppost.addRequestHeader(new Header(HttpHeaders.X_NO_OP, "Wibble"));
+                httppost.addHeader(HttpHeaders.X_NO_OP, "Wibble");
             }else{
-                httppost.addRequestHeader(new Header(HttpHeaders.X_NO_OP, Boolean
-					.toString(message.isNoOp())));
+                httppost.addHeader(HttpHeaders.X_NO_OP, Boolean
+					.toString(message.isNoOp()));
             }
-			httppost.addRequestHeader(new Header(HttpHeaders.X_VERBOSE, Boolean
-					.toString(message.isVerbose())));
+            httppost.addHeader(HttpHeaders.X_VERBOSE, Boolean
+					.toString(message.isVerbose()));
 
-			String packaging = message.getPackaging();
-			if (packaging != null && packaging.length() > 0) {
-				httppost.addRequestHeader(new Header(
-						HttpHeaders.X_PACKAGING, packaging));
-			}
+            String packaging = message.getPackaging();
+            if (packaging != null && packaging.length() > 0) {
+                httppost.addHeader(HttpHeaders.X_PACKAGING, packaging);
+            }
 
-			String onBehalfOf = message.getOnBehalfOf();
-			if (containsValue(onBehalfOf)) {
-				httppost.addRequestHeader(new Header(
-						HttpHeaders.X_ON_BEHALF_OF, onBehalfOf));
-			}
-			
-			String userAgent = message.getUserAgent();
-			if (containsValue(userAgent)) {
-				httppost.addRequestHeader(new Header(
-						HttpHeaders.USER_AGENT, userAgent));
-			}
-			
-			
-			FileRequestEntity requestEntity = new FileRequestEntity(
-			   new File(message.getFilepath()), message.getFiletype());
-			httppost.setRequestEntity(requestEntity);
+            String onBehalfOf = message.getOnBehalfOf();
+            if (containsValue(onBehalfOf)) {
+                httppost.addHeader(HttpHeaders.X_ON_BEHALF_OF, onBehalfOf);
+            }
 
-			client.executeMethod(httppost);
-			status = new Status(httppost.getStatusCode(), httppost
-					.getStatusText());
+            String userAgent = message.getUserAgent();
+            if (containsValue(userAgent)) {
+                httppost.addHeader(HttpHeaders.USER_AGENT, userAgent);
+            }
 
-			log.info("Checking the status code: " + status.getCode());
+            FileEntity requestEntity = new FileEntity(
+                    new File(message.getFilepath()),
+                    ContentType.create(message.getFiletype()));
+            httppost.setEntity(requestEntity);
 
-			if (status.getCode() == HttpStatus.SC_ACCEPTED
-					|| status.getCode() == HttpStatus.SC_CREATED) {
-				messageBody = readResponse(httppost
-						.getResponseBodyAsStream());
-				response = new DepositResponse(status.getCode()); 
-				response.setLocation(httppost.getResponseHeader("Location").getValue());
-				// added call for the status code.
-				lastUnmarshallInfo = response.unmarshall(messageBody, new Properties());
-			}
-			else {
-				messageBody = readResponse(httppost
-						.getResponseBodyAsStream());
-				response = new DepositResponse(status.getCode());
-				response.unmarshallErrorDocument(messageBody);
-			}
-			return response;
+            HttpClient client = clientBuilder.build();
+            HttpResponse httpResponse = client.execute(httppost, context);
+            StatusLine statusLine = httpResponse.getStatusLine();
+            status = new Status(statusLine.getStatusCode(),
+                    statusLine.getReasonPhrase());
 
-		} catch (NoSuchAlgorithmException nex) {
-			throw new SWORDClientException("Unable to use MD5. "
-					+ nex.getMessage(), nex);
-		} catch (HttpException ex) {
-			throw new SWORDClientException(ex.getMessage(), ex);
-		} catch (IOException ioex) {
-			throw new SWORDClientException(ioex.getMessage(), ioex);
-		} catch (UnmarshallException uex) {
-			throw new SWORDClientException(uex.getMessage() + "(<pre>" + messageBody + "</pre>)", uex);
-		} finally {
-			httppost.releaseConnection();
-		}
+            log.info("Checking the status code: " + status.getCode());
+
+            if (status.getCode() == HttpStatus.SC_ACCEPTED
+                            || status.getCode() == HttpStatus.SC_CREATED) {
+                messageBody = readResponse(httpResponse
+                        .getEntity().getContent());
+                response = new DepositResponse(status.getCode());
+                response.setLocation(httpResponse
+                        .getFirstHeader("Location").getValue());
+                // added call for the status code.
+                lastUnmarshallInfo = response.unmarshall(messageBody, new Properties());
+            }
+            else {
+                messageBody = readResponse(httpResponse
+                                .getEntity().getContent());
+                response = new DepositResponse(status.getCode());
+                response.unmarshallErrorDocument(messageBody);
+            }
+            return response;
+
+            } catch (NoSuchAlgorithmException nex) {
+                throw new SWORDClientException("Unable to use MD5. "
+                                    + nex.getMessage(), nex);
+            } catch (ClientProtocolException ex) {
+                throw new SWORDClientException(ex.getMessage(), ex);
+            } catch (IOException ioex) {
+                throw new SWORDClientException(ioex.getMessage(), ioex);
+            } catch (UnmarshallException uex) {
+                throw new SWORDClientException(uex.getMessage() + "(<pre>" + messageBody + "</pre>)", uex);
+            } finally {
+                httppost.releaseConnection();
+            }
 	}
 
 	/**
 	 * Read a response from the stream and return it as a string.
-	 * 
+	 *
 	 * @param stream
 	 *            The stream that contains the response.
 	 * @return The string extracted from the screen.
-	 * 
+	 *
 	 * @throws UnsupportedEncodingException
 	 * @throws IOException
 	 */
@@ -491,16 +538,17 @@ public class Client implements SWORDClient {
 	/**
 	 * Return the status information that was returned from the most recent
 	 * request sent to the server.
-	 * 
+	 *
 	 * @return The status code returned from the most recent access.
 	 */
+        @Override
 	public Status getStatus() {
 		return status;
 	}
 
 	/**
 	 * Check to see if the specified item contains a non-empty string.
-	 * 
+	 *
 	 * @param item
 	 *            The string to check.
 	 * @return True if the string is not null and has a length greater than 0


### PR DESCRIPTION
Commons HttpClient is EOL, is reported to have security issues, and clutters up projects that have otherwise moved on to HttpComponents.

Passes unit tests.  Independent testing and advice on how to further test would be appreciated.

This also tidies up a few warnings from my IDE and normalizes a lot of whitespace distractions.
